### PR TITLE
[Fix] 바코드 식품 추가 후 메인 화면으로 돌아오면 식품 추가 버튼 사라짐 오류 수정

### DIFF
--- a/IceButler_iOS/Presentation/ViewControllers/Fridge/FridgeViewController.swift
+++ b/IceButler_iOS/Presentation/ViewControllers/Fridge/FridgeViewController.swift
@@ -43,6 +43,7 @@ class FridgeViewController: TabmanViewController {
         
         tabBarController?.tabBar.isHidden = false
         navigationController?.navigationBar.isHidden = false
+        self.foodAddButton.isHidden = false
     }
     
     private func setup() {


### PR DESCRIPTION
## 📚 이슈 번호
#156 

## 💬 기타 사항
- 의논할 내용
